### PR TITLE
Plugin list page error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@ Plugin Name: Proxy IP Addresses for Cloudfront with Wordfence
 Plugin URI: https://github.com/emfluencekc/Wordfence-Cloudfront-IPs
 Description: Automatically add and update the proxy IP addresses for Cloudfront in Wordfence.
 Author: emfluence
-Version: 1.0
+Version: 1.1
 Author URI: https://emfluence.com
 Network: true
 Requires at least: 5.0
@@ -106,7 +106,6 @@ class Wordfence_Cloudfront_IP_Updater {
 	 * Add some basic reporting on the admin plugins page, since we don't have a settings page of our own
 	 */
 	function plugin_row_meta($plugin_meta, $plugin_file, $plugin_data, $status) {
-		if('wordfence-cloudfront-ips/plugin.php' !== $plugin_file) return;
 		$last_ran = get_option($this->last_run_option_name, false);
 		if(false === $last_ran) {
 			$plugin_meta[] = __('Has not yet run');

--- a/plugin.php
+++ b/plugin.php
@@ -106,6 +106,7 @@ class Wordfence_Cloudfront_IP_Updater {
 	 * Add some basic reporting on the admin plugins page, since we don't have a settings page of our own
 	 */
 	function plugin_row_meta($plugin_meta, $plugin_file, $plugin_data, $status) {
+		if('wordfence-cloudfront-ips/plugin.php' !== $plugin_file) return array();
 		$last_ran = get_option($this->last_run_option_name, false);
 		if(false === $last_ran) {
 			$plugin_meta[] = __('Has not yet run');

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Proxy IP Addresses for Cloudfront with Wordfence ===
 Tags: security, wordfence, cloudfront, proxy
 Requires at least: 5.0
-Tested up to: 6.1
+Tested up to: 6.4.3
 Requires PHP: 5.6
-Stable tag: 1.0
+Stable tag: 1.1
 Contributors: emfluencekc, mightyturtle
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -36,3 +36,6 @@ https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEd
 
 = 1.0 =
 Initial release. Install this plugin and your proxy IP addresses are taken care of.
+
+= 1.1 =
+Fix. Plugin list table listing error.


### PR DESCRIPTION
If the plugin path check fails function now returns an empty array() as the default.